### PR TITLE
PODS-employer-payment-nature-fix: Added default path

### DIFF
--- a/app/transformations/ETMPToFrontEnd/API1833.scala
+++ b/app/transformations/ETMPToFrontEnd/API1833.scala
@@ -203,6 +203,8 @@ private object API1833ReadsUtilities extends Transformer {
     case "Tangible moveable property held directly or indirectly by an investment-regulated pension scheme" => pathUAEmployerTangibleMoveableProperty
     case "Court Order Payment/Confiscation Order" => pathUAUnauthorisedPaymentRecipientName
     case "Other" => pathUAPaymentNatureDesc
+    // TODO: check that below resolves issue.
+    case _ => pathUAPaymentNatureEmployer
   }
 
   // TODO: refactor


### PR DESCRIPTION
Code:
+ Added default path to dynamicPathFreeTxtEmployer, which will store unspecified into __ \ "paymentNatureEmployer"