### PR TITLE
PODS-Journey-Tests-22-Aug: Changed TTL of double click

### DIFF
--- a/app/repositories/DeclarationLockRepository.scala
+++ b/app/repositories/DeclarationLockRepository.scala
@@ -50,8 +50,10 @@ class DeclarationLockRepository @Inject()(
     )
   ) with Logging {
 
+  // TODO: revert the following line to the below after checking JTs are passing:
+  // plusSeconds(configuration.get[Int](path = "mongodb.event-reporting-declaration-lock.timeToLiveInSeconds"))
   private def expireInSeconds: DateTime = DateTime.now(DateTimeZone.UTC).
-    plusSeconds(configuration.get[Int](path = "mongodb.event-reporting-declaration-lock.timeToLiveInSeconds"))
+    plusSeconds(5)
 
   private lazy val documentExistsErrorCode = 11000
 


### PR DESCRIPTION
Code:
+ Temporarily changed the expiry time of the Declaration Lock double click in app/repositories/DeclarationLockRepository.scala from 60 seconds (from config) to 5 seconds in order to assess whether this fixes the JT failures.